### PR TITLE
fix(discovery): remove vestigial coworkSessions/.cowork row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to ClaudePortable are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Discovery no longer shows a permanently-empty `coworkSessions` row.**
+  The `%USERPROFILE%\.cowork` candidate was an unverified Spec 1.1 guess that
+  does not exist on the Store-app Claude Desktop, so its read-only EXISTS box
+  always rendered unchecked and looked like a broken toggle. Removed the
+  vestigial entry from `WindowsPathDiscovery` and its `cowork/sessions`
+  archive-prefix mapping. Cowork data is unaffected: session state under
+  `%APPDATA%\Claude\local-agent-mode-sessions` is already covered by the
+  Claude Desktop AppData path, and project folders are captured by
+  `CoworkProjectDiscovery` under `cowork-projects/<hash>`. The Discovery
+  caption now explains that EXISTS is a status indicator, not a toggle. The
+  restore-side legacy mapping for `cowork/sessions` is retained so older ZIPs
+  still restore correctly.
+
 ## [0.3.0] - 2026-05-29
 
 ### Added

--- a/src/ClaudePortable.App/Ui/Views/MainWindow.xaml
+++ b/src/ClaudePortable.App/Ui/Views/MainWindow.xaml
@@ -224,7 +224,7 @@
                     </Grid.RowDefinitions>
 
                     <TextBlock Style="{DynamicResource H1}" Text="Discovery" />
-                    <TextBlock Style="{DynamicResource Caption}" Text="What ClaudePortable found on this machine. Paths that do not exist are skipped during backup." Margin="0,0,0,20" Grid.Row="1" TextWrapping="Wrap" />
+                    <TextBlock Style="{DynamicResource Caption}" Margin="0,0,0,20" Grid.Row="1" TextWrapping="Wrap">What ClaudePortable found on this machine. The EXISTS column is a read-only status indicator, not a toggle - paths that do not exist are skipped during backup. Cowork is not listed as its own row: session state lives under <Run FontFamily="{DynamicResource MonoFont}">AppData\Roaming\Claude\local-agent-mode-sessions</Run> (already covered by the Claude Desktop AppData row), and the project folders you opened in Cowork are auto-discovered and backed up separately.</TextBlock>
 
                     <TextBlock Style="{DynamicResource H2}" Text="Claude paths" Grid.Row="2" Margin="0,0,0,8" />
                     <Border Style="{DynamicResource Card}" Padding="0" Grid.Row="3">

--- a/src/ClaudePortable.Core/Backup/BackupEngine.cs
+++ b/src/ClaudePortable.Core/Backup/BackupEngine.cs
@@ -173,7 +173,6 @@ public sealed class BackupEngine : IBackupEngine
         "claudeDesktopAppData" => "claude-desktop/appdata",
         "claudeDesktopLocalAppData" => "claude-desktop/localappdata",
         "claudeCodeUserProfile" => "claude-code/dotclaude",
-        "coworkSessions" => "cowork/sessions",
         _ => key,
     };
 

--- a/src/ClaudePortable.Core/Discovery/WindowsPathDiscovery.cs
+++ b/src/ClaudePortable.Core/Discovery/WindowsPathDiscovery.cs
@@ -29,11 +29,18 @@ public sealed class WindowsPathDiscovery : IPathDiscovery
             new[] { @"%USERPROFILE%\.claude" },
             "Spec 1.1 + verified 2026-04-22"
         ),
-        (
-            "coworkSessions",
-            new[] { @"%USERPROFILE%\.cowork" },
-            "Spec 1.1 (assumed, ProcMon pending)"
-        ),
+        // NOTE: there is intentionally no "coworkSessions" entry here.
+        // The original Spec 1.1 guess of %USERPROFILE%\.cowork was never
+        // verified and does not exist on the Store-app Claude Desktop.
+        // Phase-0 verification (docs/discovered-paths.md, 2026-04-23)
+        // established that Cowork session state actually lives under
+        // %APPDATA%\Claude\local-agent-mode-sessions\<guid>\..., which is a
+        // subfolder of "claudeDesktopAppData" above and is therefore already
+        // backed up. The user-selected project roots referenced by those
+        // sessions are captured separately by CoworkProjectDiscovery under
+        // the "cowork-projects/<hash>" archive prefix. A standalone .cowork
+        // row would only ever show EXISTS = false and would duplicate the
+        // local-agent-mode-sessions subtree in the ZIP if repointed.
         (
             "claudeDesktopLocalAppData",
             new[]


### PR DESCRIPTION
# ClaudePortable — Fix: vestigial `coworkSessions` / `.cowork` Discovery row

**Repo:** `shaase-ctrl/ClaudePortable`
**Target branch:** `claude/optimistic-ride-Eb8dj` (off `main`)
**Prepared commit:** `41f933a` — *fix(discovery): remove vestigial coworkSessions/.cowork row*

This file is a self-contained hand-off so another (local) Claude Code session — or you — can apply and push the fix. A cloud session made the change but its GitHub integration was read-only (403 on push), so it couldn't push from the sandbox.

---

## 1. The problem (what the user saw)

In the **Discovery** view, the `coworkSessions` row (`C:\Users\<user>\.cowork`) shows its **EXISTS** checkbox unchecked and it can't be ticked. It looked like a regression — "I can't select the cowork button anymore."

## 2. Root cause (two things, neither is a Claude Desktop regression)

1. **The EXISTS column was never a toggle.** The Discovery `DataGrid` is `IsReadOnly="True"` (`MainWindow.xaml`). The checkbox is a one-way status indicator bound to `{Binding Exists}` — it only reflects whether the path exists on disk. No row's checkbox is clickable, by design.
2. **`coworkSessions` pointed at an unverified guess.** `WindowsPathDiscovery.cs` mapped it to `%USERPROFILE%\.cowork`, tagged `"Spec 1.1 (assumed, ProcMon pending)"`. The project's own Phase-0 verification (`docs/discovered-paths.md:28`) established the **verified** location is `%APPDATA%\Claude\local-agent-mode-sessions\<guid>\…`. So `.cowork` does not exist on a Store-app Claude Desktop install → the box is always empty.

### Important: Cowork data was never being lost
- **Session state** lives under `%APPDATA%\Claude\local-agent-mode-sessions`, which is a subfolder of the `claudeDesktopAppData` path (`%APPDATA%\Claude`) — already backed up under archive prefix `claude-desktop/appdata/...`.
- **Project folders** are captured separately by `CoworkProjectDiscovery` (reads `userSelectedFolders` from `local_*.json`) under archive prefix `cowork-projects/<hash>`.

So the `.cowork` row was pure dead weight: redundant content, and repointing it at `local-agent-mode-sessions` would only **duplicate** that subtree in the ZIP.

## 3. The fix (chosen approach: remove the row + clarify UI)

Three source edits + a changelog entry:

1. **`src/ClaudePortable.Core/Discovery/WindowsPathDiscovery.cs`** — delete the `coworkSessions` tuple from `KnownPaths`; leave an explanatory comment in its place.
2. **`src/ClaudePortable.Core/Backup/BackupEngine.cs`** — remove the `"coworkSessions" => "cowork/sessions"` case from `MapArchivePrefix`.
3. **`src/ClaudePortable.App/Ui/Views/MainWindow.xaml`** — rewrite the Discovery caption to say EXISTS is a read-only status indicator (not a toggle) and explain how Cowork is captured.
4. **`CHANGELOG.md`** — add an `## [Unreleased] → Fixed` entry.

**Deliberately NOT changed:** the restore-side `LegacyRestoreMap` entry in `src/ClaudePortable.Core/Restore/RestoreEngine.cs` (`("cowork/sessions", @"%USERPROFILE%\.cowork")`) is **kept** so older backup ZIPs that contain a `cowork/sessions/` prefix still restore correctly.

## 4. How to apply

### Option A — apply the embedded patch (recommended)
Save the patch block in section 6 to `cowork-fix.patch`, then from the repo root on an up-to-date `main`:

```bash
git checkout main && git pull
git checkout -b claude/optimistic-ride-Eb8dj    # or: git switch -c ...
git am < cowork-fix.patch                        # recreates commit 41f933a
git push -u origin claude/optimistic-ride-Eb8dj
```

If `git am` complains about whitespace/context, use `git apply --3way cowork-fix.patch` then commit manually.

### Option B — open a draft PR (with gh)
```bash
gh pr create --draft --base main --head claude/optimistic-ride-Eb8dj \
  --title "fix(discovery): remove vestigial coworkSessions/.cowork row" \
  --body-file cowork-discovery-fix.md
```

## 5. Verify before pushing
```bash
dotnet build ClaudePortable.slnx -c Debug
dotnet test                 # solution pins .NET SDK 10.0.102 (see global.json)
```
> Note: the cloud session could not compile (no .NET SDK in the sandbox). Please build/test locally before merging.

Spot checks:
- Discovery view shows **4** rows? No — it now shows **3** Claude-path rows (the `coworkSessions` row is gone). The "DISCOVERED" count on the Status tab drops by one accordingly.
- Restore of an *old* ZIP containing `cowork/sessions/` still maps to `%USERPROFILE%\.cowork` (legacy map intact).

## 6. The patch

```patch
From 41f933a89b92757d17e0c136bd6363bf275713b4 Mon Sep 17 00:00:00 2001
From: Claude <noreply@anthropic.com>
Date: Mon, 1 Jun 2026 14:25:02 +0000
Subject: [PATCH] fix(discovery): remove vestigial coworkSessions/.cowork row

The %USERPROFILE%\.cowork candidate was an unverified Spec 1.1 guess
that does not exist on the Store-app Claude Desktop, so its read-only
EXISTS checkbox always rendered unchecked and looked like a broken
toggle. Cowork session state actually lives under
%APPDATA%\Claude\local-agent-mode-sessions (already covered by the
Claude Desktop AppData path) and project folders are captured by
CoworkProjectDiscovery under cowork-projects/<hash>, so the row was
redundant.

- Drop the coworkSessions entry from WindowsPathDiscovery and its
  cowork/sessions archive-prefix mapping in BackupEngine.
- Keep the restore-side LegacyRestoreMap entry so older ZIPs that
  contain a cowork/sessions/ prefix still restore.
- Clarify the Discovery caption: EXISTS is a status indicator, not a
  toggle, and explain how Cowork is captured.
---
 CHANGELOG.md                                    | 17 +++++++++++++++++
 src/ClaudePortable.App/Ui/Views/MainWindow.xaml |  2 +-
 src/ClaudePortable.Core/Backup/BackupEngine.cs  |  1 -
 .../Discovery/WindowsPathDiscovery.cs           | 17 ++++++++++++-----
 4 files changed, 30 insertions(+), 7 deletions(-)

diff --git a/CHANGELOG.md b/CHANGELOG.md
index 13ee4a5..6079391 100644
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to ClaudePortable are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Discovery no longer shows a permanently-empty `coworkSessions` row.**
+  The `%USERPROFILE%\.cowork` candidate was an unverified Spec 1.1 guess that
+  does not exist on the Store-app Claude Desktop, so its read-only EXISTS box
+  always rendered unchecked and looked like a broken toggle. Removed the
+  vestigial entry from `WindowsPathDiscovery` and its `cowork/sessions`
+  archive-prefix mapping. Cowork data is unaffected: session state under
+  `%APPDATA%\Claude\local-agent-mode-sessions` is already covered by the
+  Claude Desktop AppData path, and project folders are captured by
+  `CoworkProjectDiscovery` under `cowork-projects/<hash>`. The Discovery
+  caption now explains that EXISTS is a status indicator, not a toggle. The
+  restore-side legacy mapping for `cowork/sessions` is retained so older ZIPs
+  still restore correctly.
+
 ## [0.3.0] - 2026-05-29
 
 ### Added
diff --git a/src/ClaudePortable.App/Ui/Views/MainWindow.xaml b/src/ClaudePortable.App/Ui/Views/MainWindow.xaml
index 63060c6..eb1d66f 100644
--- a/src/ClaudePortable.App/Ui/Views/MainWindow.xaml
+++ b/src/ClaudePortable.App/Ui/Views/MainWindow.xaml
@@ -224,7 +224,7 @@
                     </Grid.RowDefinitions>
 
                     <TextBlock Style="{DynamicResource H1}" Text="Discovery" />
-                    <TextBlock Style="{DynamicResource Caption}" Text="What ClaudePortable found on this machine. Paths that do not exist are skipped during backup." Margin="0,0,0,20" Grid.Row="1" TextWrapping="Wrap" />
+                    <TextBlock Style="{DynamicResource Caption}" Margin="0,0,0,20" Grid.Row="1" TextWrapping="Wrap">What ClaudePortable found on this machine. The EXISTS column is a read-only status indicator, not a toggle - paths that do not exist are skipped during backup. Cowork is not listed as its own row: session state lives under <Run FontFamily="{DynamicResource MonoFont}">AppData\Roaming\Claude\local-agent-mode-sessions</Run> (already covered by the Claude Desktop AppData row), and the project folders you opened in Cowork are auto-discovered and backed up separately.</TextBlock>
 
                     <TextBlock Style="{DynamicResource H2}" Text="Claude paths" Grid.Row="2" Margin="0,0,0,8" />
                     <Border Style="{DynamicResource Card}" Padding="0" Grid.Row="3">
diff --git a/src/ClaudePortable.Core/Backup/BackupEngine.cs b/src/ClaudePortable.Core/Backup/BackupEngine.cs
index ed659a9..b697187 100644
--- a/src/ClaudePortable.Core/Backup/BackupEngine.cs
+++ b/src/ClaudePortable.Core/Backup/BackupEngine.cs
@@ -173,7 +173,6 @@ public sealed class BackupEngine : IBackupEngine
         "claudeDesktopAppData" => "claude-desktop/appdata",
         "claudeDesktopLocalAppData" => "claude-desktop/localappdata",
         "claudeCodeUserProfile" => "claude-code/dotclaude",
-        "coworkSessions" => "cowork/sessions",
         _ => key,
     };
 
diff --git a/src/ClaudePortable.Core/Discovery/WindowsPathDiscovery.cs b/src/ClaudePortable.Core/Discovery/WindowsPathDiscovery.cs
index 2b8e28c..9d3eb5b 100644
--- a/src/ClaudePortable.Core/Discovery/WindowsPathDiscovery.cs
+++ b/src/ClaudePortable.Core/Discovery/WindowsPathDiscovery.cs
@@ -29,11 +29,18 @@ public sealed class WindowsPathDiscovery : IPathDiscovery
             new[] { @"%USERPROFILE%\.claude" },
             "Spec 1.1 + verified 2026-04-22"
         ),
-        (
-            "coworkSessions",
-            new[] { @"%USERPROFILE%\.cowork" },
-            "Spec 1.1 (assumed, ProcMon pending)"
-        ),
+        // NOTE: there is intentionally no "coworkSessions" entry here.
+        // The original Spec 1.1 guess of %USERPROFILE%\.cowork was never
+        // verified and does not exist on the Store-app Claude Desktop.
+        // Phase-0 verification (docs/discovered-paths.md, 2026-04-23)
+        // established that Cowork session state actually lives under
+        // %APPDATA%\Claude\local-agent-mode-sessions\<guid>\..., which is a
+        // subfolder of "claudeDesktopAppData" above and is therefore already
+        // backed up. The user-selected project roots referenced by those
+        // sessions are captured separately by CoworkProjectDiscovery under
+        // the "cowork-projects/<hash>" archive prefix. A standalone .cowork
+        // row would only ever show EXISTS = false and would duplicate the
+        // local-agent-mode-sessions subtree in the ZIP if repointed.
         (
             "claudeDesktopLocalAppData",
             new[]
-- 
2.43.0
```
