### PR TITLE
chore(release): 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-06-01
+
 ### Fixed
 
 - **Discovery no longer shows a permanently-empty `coworkSessions` row.**

--- a/scripts/build-exe.ps1
+++ b/scripts/build-exe.ps1
@@ -15,11 +15,11 @@
     Debug or Release (default Release).
 
 .EXAMPLE
-    pwsh .\build-exe.ps1 -Version 0.3.0
+    pwsh .\build-exe.ps1 -Version 0.3.1
 #>
 
 param(
-  [string] $Version = "0.3.0",
+  [string] $Version = "0.3.1",
   [string] $Configuration = "Release"
 )
 

--- a/src/ClaudePortable.Installer/build-msi.ps1
+++ b/src/ClaudePortable.Installer/build-msi.ps1
@@ -10,7 +10,7 @@
 #   pwsh .\build-msi.ps1 [-Version 0.1.0] [-Configuration Release]
 
 param(
-  [string] $Version = "0.3.0",
+  [string] $Version = "0.3.1",
   [string] $Configuration = "Release"
 )
 


### PR DESCRIPTION
Patch release bundling the coworkSessions Discovery fix (#10).

- CHANGELOG: promote Unreleased Fixed entry to `[0.3.1] - 2026-06-01`
- Default `-Version` bumped `0.3.0` -> `0.3.1` in `scripts/build-exe.ps1` and `src/ClaudePortable.Installer/build-msi.ps1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)