### PR TITLE
fix(ui): make backup destination selectable across multiple targets

### DIFF
--- a/src/ClaudePortable.App/Ui/ViewModels/MainViewModel.cs
+++ b/src/ClaudePortable.App/Ui/ViewModels/MainViewModel.cs
@@ -90,6 +90,13 @@ public sealed class MainViewModel : ViewModelBase
 
     public bool IsNotBusy => !IsBusy;
 
+    /// <summary>
+    /// The folder "Backup now" writes into: the first (top) configured target.
+    /// "Set as active" moves a target to the top, and the list order persists
+    /// in targets.json, so this survives restarts.
+    /// </summary>
+    public string ActiveTargetPath => Targets.FirstOrDefault()?.Path ?? "(none)";
+
     public string ProgressMessage
     {
         get => _progressMessage;
@@ -112,12 +119,27 @@ public sealed class MainViewModel : ViewModelBase
     public AsyncRelayCommand RefreshCommand { get; }
     public RelayCommand AddTargetCommand { get; }
     public RelayCommand RemoveTargetCommand { get; }
+    public RelayCommand SetActiveTargetCommand { get; }
     public AsyncRelayCommand RestoreCommand { get; }
     public AsyncRelayCommand RestoreFromFileCommand { get; }
     public RelayCommand PickTargetProfileCommand { get; }
     public RelayCommand OpenChecklistCommand { get; }
 
-    public TargetEntry? SelectedTarget { get; set; }
+    private TargetEntry? _selectedTarget;
+
+    public TargetEntry? SelectedTarget
+    {
+        get => _selectedTarget;
+        set
+        {
+            if (SetField(ref _selectedTarget, value))
+            {
+                RemoveTargetCommand?.RaiseCanExecuteChanged();
+                SetActiveTargetCommand?.RaiseCanExecuteChanged();
+            }
+        }
+    }
+
     public BackupEntry? SelectedBackup { get; set; }
 
     private string _postRestoreChecklistPath = string.Empty;
@@ -155,11 +177,15 @@ public sealed class MainViewModel : ViewModelBase
         RefreshCommand = new AsyncRelayCommand(RefreshAsync);
         AddTargetCommand = new RelayCommand(AddTarget);
         RemoveTargetCommand = new RelayCommand(RemoveTarget, () => SelectedTarget is not null);
+        SetActiveTargetCommand = new RelayCommand(
+            SetActiveTarget,
+            () => SelectedTarget is not null && Targets.Count > 0 && !ReferenceEquals(Targets[0], SelectedTarget));
         RestoreCommand = new AsyncRelayCommand(RestoreAsync, () => SelectedBackup is not null);
         RestoreFromFileCommand = new AsyncRelayCommand(RestoreFromFileAsync);
         PickTargetProfileCommand = new RelayCommand(PickTargetProfile);
         OpenChecklistCommand = new RelayCommand(OpenChecklist, () => !string.IsNullOrEmpty(PostRestoreChecklistPath));
 
+        Raise(nameof(ActiveTargetPath));
         _ = RefreshAsync();
     }
 
@@ -263,6 +289,7 @@ public sealed class MainViewModel : ViewModelBase
             {
                 Targets.Add(new TargetEntry(dlg.FolderName));
                 _store.Save(Targets.Select(t => t.Path).ToArray());
+                Raise(nameof(ActiveTargetPath));
                 _ = RefreshAsync();
             }
         }
@@ -276,6 +303,30 @@ public sealed class MainViewModel : ViewModelBase
         }
         Targets.Remove(SelectedTarget);
         _store.Save(Targets.Select(t => t.Path).ToArray());
+        Raise(nameof(ActiveTargetPath));
+        SetActiveTargetCommand.RaiseCanExecuteChanged();
+        _ = RefreshAsync();
+    }
+
+    /// <summary>
+    /// Move the selected target to the top of the list so it becomes the
+    /// active backup destination, and persist the new order.
+    /// </summary>
+    public void SetActiveTarget()
+    {
+        if (SelectedTarget is null)
+        {
+            return;
+        }
+        var index = Targets.IndexOf(SelectedTarget);
+        if (index <= 0)
+        {
+            return;
+        }
+        Targets.Move(index, 0);
+        _store.Save(Targets.Select(t => t.Path).ToArray());
+        Raise(nameof(ActiveTargetPath));
+        SetActiveTargetCommand.RaiseCanExecuteChanged();
         _ = RefreshAsync();
     }
 

--- a/src/ClaudePortable.App/Ui/Views/MainWindow.xaml
+++ b/src/ClaudePortable.App/Ui/Views/MainWindow.xaml
@@ -198,6 +198,7 @@
                                 Margin="0,0,8,0" />
                         <Button Content="Set as active"
                                 Command="{Binding SetActiveTargetCommand}"
+                                ToolTip="Make the selected folder the backup destination for 'Backup now'."
                                 Margin="0,0,8,0" />
                         <Button Content="Remove selected"
                                 Command="{Binding RemoveTargetCommand}" />

--- a/src/ClaudePortable.App/Ui/Views/MainWindow.xaml
+++ b/src/ClaudePortable.App/Ui/Views/MainWindow.xaml
@@ -196,8 +196,15 @@
                                 Style="{DynamicResource PrimaryButton}"
                                 Command="{Binding AddTargetCommand}"
                                 Margin="0,0,8,0" />
+                        <Button Content="Set as active"
+                                Command="{Binding SetActiveTargetCommand}"
+                                Margin="0,0,8,0" />
                         <Button Content="Remove selected"
                                 Command="{Binding RemoveTargetCommand}" />
+                        <TextBlock Style="{DynamicResource Muted}" VerticalAlignment="Center" Margin="16,0,0,0">
+                            <Run Text="Active target:" FontWeight="SemiBold" />
+                            <Run Text="{Binding ActiveTargetPath, Mode=OneWay}" />
+                        </TextBlock>
                     </StackPanel>
 
                     <Border Style="{DynamicResource Card}" Padding="0" Grid.Row="3">


### PR DESCRIPTION
## What

Makes the backup destination selectable when more than one target folder is configured.

## Why

The Targets tab lets you add several backup folders, but every backup only ever wrote to `Targets.First()` ([`MainViewModel.BackupNowAsync`](../blob/main/src/ClaudePortable.App/Ui/ViewModels/MainViewModel.cs)). New folders are appended to the end of the list, so the first-loaded folder was permanently the destination. Result: a second configured path was silently ignored, and you could not change the destination without removing whichever folder happened to be first.

## How

Single active-target model, with the **active target = the top entry** of the persisted list:

- **`MainViewModel.cs`**
  - `SetActiveTargetCommand` + `SetActiveTarget()` move the selected target to index 0 (`ObservableCollection.Move`) and persist the new order via `TargetStore.Save`.
  - `ActiveTargetPath` exposes the folder "Backup now" writes into.
  - `SelectedTarget` is now a notifying property that raises `CanExecuteChanged`, so Remove / Set-active buttons react to selection. (`RelayCommand` does not hook `CommandManager.RequerySuggested`, so this also fixes a pre-existing stale-enable on "Remove selected".)
  - `BackupNowAsync` is unchanged - `Targets.First()` now means the active target.
- **`MainWindow.xaml`** - "Set as active" button in the Targets tab plus an "Active target: &lt;path&gt;" indicator.

No engine/abstraction/config-schema changes. The active target persists across restarts because `targets.json` already round-trips list order, and auto-discovery appends without disturbing index 0. Auto-discovery behavior is otherwise unchanged.

## Testing

- `dotnet build` - clean (project uses `TreatWarningsAsErrors`).
- `dotnet test` - all 98 tests pass.
- Manual (reviewer spot-check, requires running the WPF app): add folder A then B → "Active target" shows A; select B → "Set as active" → B jumps to top and becomes active; "Backup now" writes the ZIP into B; relaunch → B still active.

## Notes for reviewer

- An optional unit test for `TargetStore` order round-trip was considered but skipped: `TargetStore` lives in the App project (not referenced by the test project) and writes to a hardcoded `%LOCALAPPDATA%\ClaudePortable\targets.json`, so testing it would clobber the real config or require a path-injection refactor. The order invariant is plain `JsonSerializer` `string[]` round-tripping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
