### PR TITLE
fix(ui): selectable backup target + enable Restore button on snapshot selection

### DIFF
--- a/src/ClaudePortable.App/Ui/ViewModels/MainViewModel.cs
+++ b/src/ClaudePortable.App/Ui/ViewModels/MainViewModel.cs
@@ -140,7 +140,19 @@ public sealed class MainViewModel : ViewModelBase
         }
     }
 
-    public BackupEntry? SelectedBackup { get; set; }
+    private BackupEntry? _selectedBackup;
+
+    public BackupEntry? SelectedBackup
+    {
+        get => _selectedBackup;
+        set
+        {
+            if (SetField(ref _selectedBackup, value))
+            {
+                RestoreCommand?.RaiseCanExecuteChanged();
+            }
+        }
+    }
 
     private string _postRestoreChecklistPath = string.Empty;
 

--- a/src/ClaudePortable.App/Ui/ViewModels/MainViewModel.cs
+++ b/src/ClaudePortable.App/Ui/ViewModels/MainViewModel.cs
@@ -90,6 +90,13 @@ public sealed class MainViewModel : ViewModelBase
 
     public bool IsNotBusy => !IsBusy;
 
+    /// <summary>
+    /// The folder "Backup now" writes into: the first (top) configured target.
+    /// "Set as active" moves a target to the top, and the list order persists
+    /// in targets.json, so this survives restarts.
+    /// </summary>
+    public string ActiveTargetPath => Targets.FirstOrDefault()?.Path ?? "(none)";
+
     public string ProgressMessage
     {
         get => _progressMessage;
@@ -112,12 +119,27 @@ public sealed class MainViewModel : ViewModelBase
     public AsyncRelayCommand RefreshCommand { get; }
     public RelayCommand AddTargetCommand { get; }
     public RelayCommand RemoveTargetCommand { get; }
+    public RelayCommand SetActiveTargetCommand { get; }
     public AsyncRelayCommand RestoreCommand { get; }
     public AsyncRelayCommand RestoreFromFileCommand { get; }
     public RelayCommand PickTargetProfileCommand { get; }
     public RelayCommand OpenChecklistCommand { get; }
 
-    public TargetEntry? SelectedTarget { get; set; }
+    private TargetEntry? _selectedTarget;
+
+    public TargetEntry? SelectedTarget
+    {
+        get => _selectedTarget;
+        set
+        {
+            if (SetField(ref _selectedTarget, value))
+            {
+                RemoveTargetCommand?.RaiseCanExecuteChanged();
+                SetActiveTargetCommand?.RaiseCanExecuteChanged();
+            }
+        }
+    }
+
     public BackupEntry? SelectedBackup { get; set; }
 
     private string _postRestoreChecklistPath = string.Empty;
@@ -155,11 +177,15 @@ public sealed class MainViewModel : ViewModelBase
         RefreshCommand = new AsyncRelayCommand(RefreshAsync);
         AddTargetCommand = new RelayCommand(AddTarget);
         RemoveTargetCommand = new RelayCommand(RemoveTarget, () => SelectedTarget is not null);
+        SetActiveTargetCommand = new RelayCommand(
+            SetActiveTarget,
+            () => SelectedTarget is not null && Targets.Count > 0 && !ReferenceEquals(Targets[0], SelectedTarget));
         RestoreCommand = new AsyncRelayCommand(RestoreAsync, () => SelectedBackup is not null);
         RestoreFromFileCommand = new AsyncRelayCommand(RestoreFromFileAsync);
         PickTargetProfileCommand = new RelayCommand(PickTargetProfile);
         OpenChecklistCommand = new RelayCommand(OpenChecklist, () => !string.IsNullOrEmpty(PostRestoreChecklistPath));
 
+        Raise(nameof(ActiveTargetPath));
         _ = RefreshAsync();
     }
 
@@ -263,6 +289,7 @@ public sealed class MainViewModel : ViewModelBase
             {
                 Targets.Add(new TargetEntry(dlg.FolderName));
                 _store.Save(Targets.Select(t => t.Path).ToArray());
+                Raise(nameof(ActiveTargetPath));
                 _ = RefreshAsync();
             }
         }
@@ -276,6 +303,30 @@ public sealed class MainViewModel : ViewModelBase
         }
         Targets.Remove(SelectedTarget);
         _store.Save(Targets.Select(t => t.Path).ToArray());
+        Raise(nameof(ActiveTargetPath));
+        SetActiveTargetCommand.RaiseCanExecuteChanged();
+        _ = RefreshAsync();
+    }
+
+    /// <summary>
+    /// Move the selected target to the top of the list so it becomes the
+    /// active backup destination, and persist the new order.
+    /// </summary>
+    public void SetActiveTarget()
+    {
+        if (SelectedTarget is null)
+        {
+            return;
+        }
+        var index = Targets.IndexOf(SelectedTarget);
+        if (index <= 0)
+        {
+            return;
+        }
+        Targets.Move(index, 0);
+        _store.Save(Targets.Select(t => t.Path).ToArray());
+        Raise(nameof(ActiveTargetPath));
+        SetActiveTargetCommand.RaiseCanExecuteChanged();
         _ = RefreshAsync();
     }
 

--- a/src/ClaudePortable.App/Ui/Views/MainWindow.xaml
+++ b/src/ClaudePortable.App/Ui/Views/MainWindow.xaml
@@ -198,6 +198,7 @@
                                 Margin="0,0,8,0" />
                         <Button Content="Set as active"
                                 Command="{Binding SetActiveTargetCommand}"
+                                ToolTip="Make the selected folder the backup destination for 'Backup now'."
                                 Margin="0,0,8,0" />
                         <Button Content="Remove selected"
                                 Command="{Binding RemoveTargetCommand}" />

--- a/src/ClaudePortable.App/Ui/Views/MainWindow.xaml
+++ b/src/ClaudePortable.App/Ui/Views/MainWindow.xaml
@@ -196,8 +196,15 @@
                                 Style="{DynamicResource PrimaryButton}"
                                 Command="{Binding AddTargetCommand}"
                                 Margin="0,0,8,0" />
+                        <Button Content="Set as active"
+                                Command="{Binding SetActiveTargetCommand}"
+                                Margin="0,0,8,0" />
                         <Button Content="Remove selected"
                                 Command="{Binding RemoveTargetCommand}" />
+                        <TextBlock Style="{DynamicResource Muted}" VerticalAlignment="Center" Margin="16,0,0,0">
+                            <Run Text="Active target:" FontWeight="SemiBold" />
+                            <Run Text="{Binding ActiveTargetPath, Mode=OneWay}" />
+                        </TextBlock>
                     </StackPanel>
 
                     <Border Style="{DynamicResource Card}" Padding="0" Grid.Row="3">


### PR DESCRIPTION
## Summary

- Make the backup destination selectable across multiple configured targets via a single active-target model ("Set as active" + active-target indicator).
- Fix the Restore tab: "Restore selected snapshot" stayed permanently greyed out because `SelectedBackup` raised no change notification and `AsyncRelayCommand` does not hook `CommandManager.RequerySuggested`, so `CanExecute` was evaluated once (null -> disabled) and never re-queried. `SelectedBackup` is now a notifying property that raises `RestoreCommand.RaiseCanExecuteChanged()`, mirroring the `SelectedTarget` fix.

Restore bug reported by Marga Busqui (Penelope CAD): selecting a snapshot left the restore button disabled. "Restore from file..." was unaffected.

## Verification

- `dotnet build ClaudePortable.slnx` - clean (0 warnings, 0 errors).
- Restore tab: button disabled with no selection, enables on row select, fires the confirm dialog on click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)