### PR TITLE
fix(ui): enable Restore button when a snapshot is selected

### DIFF
--- a/src/ClaudePortable.App/Ui/ViewModels/MainViewModel.cs
+++ b/src/ClaudePortable.App/Ui/ViewModels/MainViewModel.cs
@@ -140,7 +140,19 @@ public sealed class MainViewModel : ViewModelBase
         }
     }
 
-    public BackupEntry? SelectedBackup { get; set; }
+    private BackupEntry? _selectedBackup;
+
+    public BackupEntry? SelectedBackup
+    {
+        get => _selectedBackup;
+        set
+        {
+            if (SetField(ref _selectedBackup, value))
+            {
+                RestoreCommand?.RaiseCanExecuteChanged();
+            }
+        }
+    }
 
     private string _postRestoreChecklistPath = string.Empty;
 


### PR DESCRIPTION
## Summary

The "Restore selected snapshot" button on the Restore tab stayed permanently greyed out: `RestoreCommand.CanExecute` is `SelectedBackup is not null`, but `SelectedBackup` was a plain auto-property raising no change notification, and `AsyncRelayCommand` does not hook `CommandManager.RequerySuggested`. WPF evaluated `CanExecute` once at bind time (null -> disabled) and never re-queried on row selection.

Make `SelectedBackup` a notifying property that raises `RestoreCommand.RaiseCanExecuteChanged()`, mirroring the existing `SelectedTarget` pattern. "Restore from file..." was unaffected (no `canExecute` predicate).

Reported by Marga Busqui (Penelope CAD): selecting a snapshot left the restore button disabled.

## Verification

- `dotnet build ClaudePortable.slnx` - clean (0 warnings, 0 errors).
- Restore tab: button disabled with no selection, enables on row select, fires the confirm dialog on click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)