### PR TITLE
chore(release): 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-06-03
+
+### Fixed
+
+- **Restore button stayed disabled after selecting a snapshot.** On the Restore
+  tab, "Restore selected snapshot" is gated on a backup being selected, but
+  `SelectedBackup` raised no change notification and `AsyncRelayCommand` does not
+  hook `CommandManager.RequerySuggested`, so its `CanExecute` was evaluated once
+  (nothing selected -> disabled) and never re-queried when a row was picked - the
+  button was therefore permanently greyed out. `SelectedBackup` is now a notifying
+  property that raises `RestoreCommand` `CanExecuteChanged`, matching the existing
+  `SelectedTarget` fix. "Restore from file..." was unaffected and was the
+  workaround on 0.3.1.
+
 ## [0.3.1] - 2026-06-01
 
 ### Fixed

--- a/scripts/build-exe.ps1
+++ b/scripts/build-exe.ps1
@@ -15,11 +15,11 @@
     Debug or Release (default Release).
 
 .EXAMPLE
-    pwsh .\build-exe.ps1 -Version 0.3.1
+    pwsh .\build-exe.ps1 -Version 0.3.2
 #>
 
 param(
-  [string] $Version = "0.3.1",
+  [string] $Version = "0.3.2",
   [string] $Configuration = "Release"
 )
 

--- a/src/ClaudePortable.Installer/build-msi.ps1
+++ b/src/ClaudePortable.Installer/build-msi.ps1
@@ -10,7 +10,7 @@
 #   pwsh .\build-msi.ps1 [-Version 0.1.0] [-Configuration Release]
 
 param(
-  [string] $Version = "0.3.1",
+  [string] $Version = "0.3.2",
   [string] $Configuration = "Release"
 )
 


### PR DESCRIPTION
Release 0.3.2 - ships the Restore-button enable fix (#14).

- CHANGELOG: add 0.3.2 section.
- `scripts/build-exe.ps1` and `src/ClaudePortable.Installer/build-msi.ps1` default version 0.3.1 -> 0.3.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)